### PR TITLE
Feature, disable text option added

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -27,3 +27,5 @@ import { getBrands, createPills } from '/src/main.ts'
     document.getElementById('example9').append(createPills(exampleAlign, { outline: true }))
     // links enabled
     document.getElementById('example10').append(createPills(exampleAlign, { links: true }))
+    // text enabled
+    document.getElementById('example11').append(createPills(exampleAlign, { text: false }))

--- a/example/style.css
+++ b/example/style.css
@@ -84,6 +84,7 @@ section.intro {
   background:#fff;
   text-align: center;
   background: #8d98e7;
+  background-image: linear-gradient(357deg, #00000040, #00000040, transparent);
   text-align: center;
   color: #fff;
 }

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
             <li><a href="#exampleIconsEnabledTitle">Icon Visibility </a></li>
             <li><a href="#exampleOutlineTitle">Outline</a></li>
             <li><a href="#exampleLinkTitle">Links</a></li>
+            <li><a href="#exampleTextTitle">Text</a></li>
           </ul>
         </div>
       </div>
@@ -63,7 +64,8 @@
             If an empty array is passed as the first argument, createPills will return the full list of Pills. Useful for debugging.</p> 
           <hr class="divider">
           <h3>OptionsObject</h3>
-          <p>The second argument, is an Object with the following <b>OPTIONAL</b> attributes</p>
+          <p>The second argument, is an Object with the following <b>OPTIONAL</b> attributes</p>. 
+          <p>By combining options together, you can truly customise CodePills to your project. </p>
           <table class="configTable" cellspacing="0">
             <thead>
               <tr>
@@ -115,6 +117,13 @@
                 <td>Enable linking to brand homepage, if exists</td>
                 <td>Boolean</td>
                 <td>false</td>
+                <td>true, false</td>
+              </tr>
+              <tr>
+                <td><a href="#exampleTextTitle" title="jump to Text">Text</a></td>
+                <td>Enable Human Readable text in the pill.</td>
+                <td>Boolean</td>
+                <td>true</td>
                 <td>true, false</td>
               </tr>
             </tbody>
@@ -197,11 +206,20 @@
 
         <section arira-labelledby="exampleLinkTitle">
           <h2 id="exampleLinkTitle">Link Example:</h2>
-          <p>You can enable or links, if available. They will open in a new tab.</p>
+          <p>You can enable or disable links. <br> If available. They will open in a new tab.</p>
           <p><b>Example:</b></p>
           <pre><code class="lang-js">createPills([],{ links: true})</code></pre>
             <p><b>Generates:</b></p>
           <div id="example10"></div>
+        </section>
+
+        <section arira-labelledby="exampleTextTitle">
+          <h2 id="exampleTextTitle">Text Example:</h2>
+          <p>You can enable or text. If disabled, text will not show in the pip.</p>
+          <p><b>Example:</b></p>
+          <pre><code class="lang-js">createPills([],{ text: false})</code></pre>
+            <p><b>Generates:</b></p>
+          <div id="example11"></div>
         </section>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -216,6 +216,12 @@
         <section arira-labelledby="exampleTextTitle">
           <h2 id="exampleTextTitle">Text Example:</h2>
           <p>You can enable or text. If disabled, text will not show in the pip.</p>
+
+          <p class="note">
+            <i class="mdi mdi-information"></i>
+            If you disable text and also disable Icons - text will be output to ensure items are not empty.
+          </p>
+
           <p><b>Example:</b></p>
           <pre><code class="lang-js">createPills([],{ text: false})</code></pre>
             <p><b>Generates:</b></p>

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,14 +29,15 @@ function cleanBrandInput(inputArray: string[]){
   return null
 }
 
-function createPillItem(
+function createPill(
   item: { brandName: string; mdiIcon: string | null; humanReadable: string, url: string },
   options: { 
     links?:   boolean
     rounded?: boolean
     outline?: boolean
     spacing?: 'small' | 'medium' | 'large'
-    iconsEnabled?: boolean;
+    iconsEnabled?: boolean
+    text?: boolean
   } = {}){
 
   // Deconstruct the options, set default values on items
@@ -45,7 +46,8 @@ function createPillItem(
     rounded = false,
     outline = false,
     spacing = 'small', 
-    iconsEnabled = true
+    iconsEnabled = true,
+    text = true
   } = options
 
   let element: HTMLElement | HTMLAnchorElement;
@@ -81,13 +83,18 @@ function createPillItem(
     element.classList.add('outline')
   }
 
-  if (['small', 'medium', 'large'].includes(spacing)) {
+  if(['small', 'medium', 'large'].includes(spacing)) {
     element.classList.add('spaced-' + spacing)
   }
 
-  let readableText = document.createElement('span')
-  readableText.innerText = item.humanReadable
-  element.append(readableText)
+  if(text){
+    let readableText = document.createElement('span')
+    readableText.innerText = item.humanReadable
+    element.append(readableText)
+  }else{
+    element.classList.add('no-text')
+  }
+
   return element
 }
 
@@ -101,7 +108,8 @@ export function createPills(
     outline?: boolean
     spacing?: 'small' | 'medium' | 'large' 
     align?: 'left' | 'center' | 'centre' | 'right'
-    iconsEnabled?: boolean
+    iconsEnabled?: boolean,
+    text?: boolean,
   } = {}){
 
   // deconstruct from options
@@ -111,7 +119,8 @@ export function createPills(
     outline = false,
     spacing = 'small', 
     align = 'left',
-    iconsEnabled = true
+    iconsEnabled = true,
+    text = true
   } = options
 
   // HTML node elements we inject into each other or DOM
@@ -141,13 +150,13 @@ export function createPills(
   // If user does not provide
   if(!brandListInput || brandListInput.length === 0){
     brands.forEach(item => {
-      const pill = createPillItem(item, { links, rounded, outline, spacing, iconsEnabled })
+      const pill = createPill(item, { links, rounded, outline, spacing, iconsEnabled, text })
       pills.push(pill)      
     })
   } else {
     matchingBrands.forEach((item) => {
       if (item) {
-        const pill = createPillItem(item, { links, rounded, outline, spacing, iconsEnabled })
+        const pill = createPill(item, { links, rounded, outline, spacing, iconsEnabled, text })
         pills.push(pill);
       }
     })

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,7 +87,7 @@ function createPill(
     element.classList.add('spaced-' + spacing)
   }
 
-  if(text){
+  if(text || !text && !iconsEnabled){
     let readableText = document.createElement('span')
     readableText.innerText = item.humanReadable
     element.append(readableText)

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -32,6 +32,12 @@
       border: 1px solid;
     }
 
+    &.no-text {
+      i {
+        margin-right: auto;
+      }
+    }
+
     // Give spacing options
     &.spaced-small {
       margin: 0 3px 3px 3px;


### PR DESCRIPTION
- Resolves ( #5 )
- Added option for users to disable text output in items
- Added failsafe, to ensure if both text and icons are disabled, text will show ( prevents mis-config )
- Updated example with appropriate information 